### PR TITLE
JQuery Compatiblity with Magento 2.4.6

### DIFF
--- a/view/adminhtml/web/js/jquery.chained.js
+++ b/view/adminhtml/web/js/jquery.chained.js
@@ -87,7 +87,7 @@ define([
                 });
 
                 /* If we have only the default value disable select. */
-                if (1 === $("option", child).size() && $(child).val() === "") {
+                if (1 === $("option", child).length && $(child).val() === "") {
                     $(child).prop("disabled", true);
                 } else {
                     $(child).prop("disabled", false);


### PR DESCRIPTION
Magento 2.4.6 removed the usage of jquery migrate which had the `size()` function backward compatibility covered. Now, the function does not exist and the usage of `size()` is changed to `length`.

[source]

[source]: https://experienceleague.adobe.com/docs/commerce-operations/release/notes/magento-open-source/2-4-6.html?lang=en#:~:text=jquery%2Dmigrate%20has%20been%20removed%20from%20the%20Commerce%20and%20Magento%20Open%20Source%20code%20bases.%20GitHub%2D21406